### PR TITLE
Remove dead links/nodes

### DIFF
--- a/docs/xml/Microsoft.Maui.ApplicationModel.Communication/ContactEmail.xml
+++ b/docs/xml/Microsoft.Maui.ApplicationModel.Communication/ContactEmail.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui.Essentials/ContactEmail.xml" path="Type[@FullName='Microsoft.Maui.ApplicationModel.CommunicationEmail']/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/docs/xml/Microsoft.Maui.ApplicationModel.Communication/ContactPhone.xml
+++ b/docs/xml/Microsoft.Maui.ApplicationModel.Communication/ContactPhone.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui.Essentials/ContactPhone.xml" path="Type[@FullName='Microsoft.Maui.ApplicationModel.CommunicationPhone']/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/docs/xml/Microsoft.Maui.ApplicationModel/AppActions.xml
+++ b/docs/xml/Microsoft.Maui.ApplicationModel/AppActions.xml
@@ -100,8 +100,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/AppActions.xml" path="//Member[@MemberName='OnAppAction'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetAsync">

--- a/docs/xml/Microsoft.Maui.ApplicationModel/Permissions.xml
+++ b/docs/xml/Microsoft.Maui.ApplicationModel/Permissions.xml
@@ -47,8 +47,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/Permissions.xml" path="//Member[@MemberName='CheckStatusAsync']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RequestAsync&lt;TPermission&gt;">
@@ -80,8 +78,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/Permissions.xml" path="//Member[@MemberName='RequestAsync']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ShouldShowRationale&lt;TPermission&gt;">
@@ -113,8 +109,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/Permissions.xml" path="//Member[@MemberName='ShouldShowRationale']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Authentication/WebAuthenticator.xml
+++ b/docs/xml/Microsoft.Maui.Authentication/WebAuthenticator.xml
@@ -41,8 +41,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/WebAuthenticator.xml" path="//Member[@MemberName='AuthenticateAsync'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="AuthenticateAsync">

--- a/docs/xml/Microsoft.Maui.Controls.Internals/ActionSheetArguments.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/ActionSheetArguments.xml
@@ -140,8 +140,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/ActionSheetArguments.xml" path="//Member[@MemberName='FlowDirection']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Result">

--- a/docs/xml/Microsoft.Maui.Controls.Internals/AlertArguments.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/AlertArguments.xml
@@ -116,8 +116,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/AlertArguments.xml" path="//Member[@MemberName='FlowDirection']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Message">

--- a/docs/xml/Microsoft.Maui.Controls.Internals/AsyncValueExtensions.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/AsyncValueExtensions.xml
@@ -52,8 +52,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/AsyncValueExtensions.xml" path="//Member[@MemberName='AsAsyncValue']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.Internals/CellExtensions.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/CellExtensions.xml
@@ -68,8 +68,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml" path="//Member[@MemberName='GetGroup']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetGroupHeaderContent&lt;TView,TItem&gt;">
@@ -116,8 +114,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml" path="//Member[@MemberName='GetGroupHeaderContent']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetIndex&lt;TView,TItem&gt;">
@@ -164,8 +160,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml" path="//Member[@MemberName='GetIndex']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetIsGroupHeader&lt;TView,TItem&gt;">
@@ -212,8 +206,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml" path="//Member[@MemberName='GetIsGroupHeader']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetPath">
@@ -286,8 +278,6 @@
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/CellExtensions.xml" path="//Member[@MemberName='SetIsGroupHeader']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.Internals/GIFBitmap+DisposeMethod.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/GIFBitmap+DisposeMethod.xml
@@ -35,8 +35,6 @@
       <MemberValue>1</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFBitmap.xml" path="//Member[@MemberName='LeaveInPlace']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="NoAction">
@@ -57,8 +55,6 @@
       <MemberValue>0</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFBitmap.xml" path="//Member[@MemberName='NoAction']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RestoreToBackground">
@@ -79,8 +75,6 @@
       <MemberValue>2</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFBitmap.xml" path="//Member[@MemberName='RestoreToBackground']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RestoreToPrevious">
@@ -101,8 +95,6 @@
       <MemberValue>3</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Internals/GIFBitmap.xml" path="//Member[@MemberName='RestoreToPrevious']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.Internals/Registrar.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/Registrar.xml
@@ -156,8 +156,6 @@
         <param name="effectType">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterEffect']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RegisterEffects">
@@ -232,8 +230,6 @@
         <param name="handlerShim">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='RegisterRendererToHandlerShim']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RegisterStylesheets">

--- a/docs/xml/Microsoft.Maui.Controls.Internals/Registrar`1.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Internals/Registrar`1.xml
@@ -30,8 +30,6 @@
     <typeparam name="TRegistrable">To be added.</typeparam>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="Type[@FullName='Microsoft.Maui.Controls.Internals.Registrar' and position()=0]/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -83,8 +81,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHandler&lt;TOut&gt;">
@@ -128,8 +124,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandler'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHandlerForObject&lt;TOut&gt;">
@@ -164,8 +158,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHandlerForObject&lt;TOut&gt;">
@@ -209,8 +201,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerForObject'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHandlerType">
@@ -236,8 +226,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHandlerType">
@@ -265,8 +253,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerType'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHandlerTypeForObject">
@@ -292,8 +278,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='GetHandlerTypeForObject']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Register">
@@ -320,8 +304,6 @@
         <param name="trender">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register'][3]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Register">
@@ -350,8 +332,6 @@
         <param name="supportedVisual">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Register">
@@ -382,8 +362,6 @@
         <param name="priority">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls.Internals/Registrar.xml" path="//Member[@MemberName='Register'][1]/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView+RefreshPullDirection.xml
+++ b/docs/xml/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView+RefreshPullDirection.xml
@@ -35,8 +35,6 @@
       <MemberValue>3</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='BottomToTop']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="LeftToRight">
@@ -57,8 +55,6 @@
       <MemberValue>0</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='LeftToRight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RightToLeft">
@@ -79,8 +75,6 @@
       <MemberValue>2</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='RightToLeft']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="TopToBottom">
@@ -101,8 +95,6 @@
       <MemberValue>1</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/RefreshView.xml" path="//Member[@MemberName='TopToBottom']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml
+++ b/docs/xml/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml
@@ -36,8 +36,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='ExecutionModeProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetExecutionMode">
@@ -63,8 +61,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetExecutionMode">
@@ -90,8 +86,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='GetExecutionMode'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetIsJavaScriptAlertEnabled">
@@ -188,8 +182,6 @@
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetExecutionMode">
@@ -217,8 +209,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific/WebView.xml" path="//Member[@MemberName='SetExecutionMode'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetIsJavaScriptAlertEnabled">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Ellipse.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Ellipse.xml
@@ -59,8 +59,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Ellipse.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml
@@ -82,8 +82,6 @@
         <param name="path">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/EllipseGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Center">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Geometry.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Geometry.xml
@@ -64,8 +64,6 @@
         <param name="path">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Geometry.xml" path="//Member[@MemberName='AppendPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Graphics.IShape.PathForBounds">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml
@@ -63,8 +63,6 @@
         <param name="path">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/GeometryGroup.xml" path="//Member[@MemberName='AppendPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Children">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Line.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Line.xml
@@ -64,8 +64,6 @@
         <param name="y2">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='.ctor'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetPath">
@@ -88,8 +86,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Line.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/LineGeometry.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/LineGeometry.xml
@@ -80,8 +80,6 @@
         <param name="path">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/LineGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="EndPoint">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/MatrixTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Path.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Path.xml
@@ -58,8 +58,6 @@
         <param name="data">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='.ctor'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Data">
@@ -129,8 +127,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Path.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathFigureCollectionConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ParseStringToPathFigureCollection">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/PathGeometry.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/PathGeometry.xml
@@ -107,8 +107,6 @@
         <param name="path">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Figures">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PathGeometryConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/PointCollectionConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Polygon.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Polygon.xml
@@ -58,8 +58,6 @@
         <param name="points">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='.ctor'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FillRule">
@@ -123,8 +121,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polygon.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Polyline.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Polyline.xml
@@ -58,8 +58,6 @@
         <param name="points">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='.ctor'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FillRule">
@@ -123,8 +121,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Polyline.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Rectangle.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Rectangle.xml
@@ -59,8 +59,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Rectangle.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnPropertyChanged">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml
@@ -78,8 +78,6 @@
         <param name="path">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/RectangleGeometry.xml" path="//Member[@MemberName='AppendPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Rect">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/Shape.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/Shape.xml
@@ -176,8 +176,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='GetPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapStrokeDashArray">
@@ -578,8 +576,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/Shape.xml" path="//Member[@MemberName='StrokeDashPattern']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="StrokeLineCap">

--- a/docs/xml/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls.Shapes/TransformTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/AbsoluteLayout.xml
+++ b/docs/xml/Microsoft.Maui.Controls/AbsoluteLayout.xml
@@ -329,8 +329,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutBounds'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetLayoutFlags">
@@ -429,8 +427,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/AbsoluteLayout.xml" path="//Member[@MemberName='GetLayoutFlags'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="LayoutBoundsProperty">

--- a/docs/xml/Microsoft.Maui.Controls/Animation.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Animation.xml
@@ -217,8 +217,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Animation.xml" path="//Member[@MemberName='Reset']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="WithConcurrent">

--- a/docs/xml/Microsoft.Maui.Controls/AnimationExtensions.xml
+++ b/docs/xml/Microsoft.Maui.Controls/AnimationExtensions.xml
@@ -70,8 +70,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Add']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Animate">
@@ -346,8 +344,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Insert']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Interpolate">
@@ -404,8 +400,6 @@
         <param name="tickerId">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/AnimationExtensions.xml" path="//Member[@MemberName='Remove']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Application.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Application.xml
@@ -109,8 +109,6 @@ public partial class App : Application
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Application.xml" path="//Member[@MemberName='AccentColor']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="AppLinks">

--- a/docs/xml/Microsoft.Maui.Controls/AutomationProperties.xml
+++ b/docs/xml/Microsoft.Maui.Controls/AutomationProperties.xml
@@ -53,8 +53,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='ExcludedWithChildrenProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetExcludedWithChildren">
@@ -80,8 +78,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='GetExcludedWithChildren']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetHelpText">
@@ -295,8 +291,6 @@
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/AutomationProperties.xml" path="//Member[@MemberName='SetExcludedWithChildren']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetHelpText">

--- a/docs/xml/Microsoft.Maui.Controls/BackButtonBehavior.xml
+++ b/docs/xml/Microsoft.Maui.Controls/BackButtonBehavior.xml
@@ -218,8 +218,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='IsVisible']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsVisibleProperty">
@@ -240,8 +238,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BackButtonBehavior.xml" path="//Member[@MemberName='IsVisibleProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="TextOverride">

--- a/docs/xml/Microsoft.Maui.Controls/BaseShellItem.xml
+++ b/docs/xml/Microsoft.Maui.Controls/BaseShellItem.xml
@@ -141,8 +141,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BaseShellItem.xml" path="//Member[@MemberName='FlyoutItemIsVisible']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Icon">

--- a/docs/xml/Microsoft.Maui.Controls/BindableObjectExtensions.xml
+++ b/docs/xml/Microsoft.Maui.Controls/BindableObjectExtensions.xml
@@ -49,8 +49,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BindableObjectExtensions.xml" path="//Member[@MemberName='GetPropertyIfSet']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetAppTheme&lt;T&gt;">
@@ -85,8 +83,6 @@
         <param name="dark">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BindableObjectExtensions.xml" path="//Member[@MemberName='SetAppTheme']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetAppThemeColor">

--- a/docs/xml/Microsoft.Maui.Controls/BindablePropertyConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/BindablePropertyConverter.xml
@@ -64,8 +64,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BindablePropertyConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -93,8 +91,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BindablePropertyConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -124,8 +120,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BindablePropertyConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -157,8 +151,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BindablePropertyConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">

--- a/docs/xml/Microsoft.Maui.Controls/Binding.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Binding.xml
@@ -206,8 +206,6 @@ Debug.WriteLine (person.Name); //prints "Foo". ReverseConverter.ConvertBack () i
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Binding.xml" path="//Member[@MemberName='SelfPath']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Source">

--- a/docs/xml/Microsoft.Maui.Controls/BoundsTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/BoundsTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BoundsTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BoundsTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BoundsTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/BoundsTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/BrushTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/BrushTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BrushTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BrushTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BrushTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/BrushTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Hsl">

--- a/docs/xml/Microsoft.Maui.Controls/Button.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Button.xml
@@ -478,8 +478,6 @@ void IncrementLabel()
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='ControlsButtonMapper']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -583,8 +581,6 @@ void IncrementLabel()
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -605,8 +601,6 @@ void IncrementLabel()
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -798,8 +792,6 @@ void IncrementLabel()
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='LineBreakMode']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="LineBreakModeProperty">
@@ -820,8 +812,6 @@ void IncrementLabel()
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='LineBreakModeProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapContentLayout">
@@ -848,8 +838,6 @@ void IncrementLabel()
         <param name="button">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='MapContentLayout']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapLineBreakMode">
@@ -902,8 +890,6 @@ void IncrementLabel()
         <param name="button">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Button.xml" path="//Member[@MemberName='MapText']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBorderElement.BorderColorDefaultValue">

--- a/docs/xml/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/CarouselLayoutTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/CheckBox.xml
+++ b/docs/xml/Microsoft.Maui.Controls/CheckBox.xml
@@ -158,8 +158,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/CheckBox.xml" path="//Member[@MemberName='Foreground']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsChecked">

--- a/docs/xml/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ColumnDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Command`1.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Command`1.xml
@@ -20,8 +20,6 @@
     <typeparam name="T">To be added.</typeparam>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui.Controls/Command.xml" path="Type[@FullName='Microsoft.Maui.Controls.Command' and position()=0]/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/docs/xml/Microsoft.Maui.Controls/DatePicker.xml
+++ b/docs/xml/Microsoft.Maui.Controls/DatePicker.xml
@@ -269,8 +269,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -291,8 +289,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DatePicker.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/DependencyService.xml
+++ b/docs/xml/Microsoft.Maui.Controls/DependencyService.xml
@@ -54,8 +54,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Get']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Register">
@@ -80,8 +78,6 @@
         <param name="assemblies">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register'][3]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Register&lt;T&gt;">
@@ -117,8 +113,6 @@
         <typeparam name="T">To be added.</typeparam>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Register&lt;T,TImpl&gt;">
@@ -167,8 +161,6 @@
         <typeparam name="TImpl">To be added.</typeparam>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Register'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RegisterSingleton&lt;T&gt;">
@@ -207,8 +199,6 @@
         <param name="instance">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='RegisterSingleton']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Resolve&lt;T&gt;">
@@ -247,8 +237,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DependencyService.xml" path="//Member[@MemberName='Resolve']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/DoubleCollection.xml
+++ b/docs/xml/Microsoft.Maui.Controls/DoubleCollection.xml
@@ -63,8 +63,6 @@
         <param name="values">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DoubleCollection.xml" path="//Member[@MemberName='.ctor'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">

--- a/docs/xml/Microsoft.Maui.Controls/DoubleCollectionConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/DoubleCollectionConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DoubleCollectionConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DoubleCollectionConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DoubleCollectionConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/DoubleCollectionConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Editor.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Editor.xml
@@ -246,8 +246,6 @@ var editor = new Editor {
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='CursorPosition']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CursorPositionProperty">
@@ -268,8 +266,6 @@ var editor = new Editor {
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='CursorPositionProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -332,8 +328,6 @@ var editor = new Editor {
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -354,8 +348,6 @@ var editor = new Editor {
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -465,8 +457,6 @@ var editor = new Editor {
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='HorizontalTextAlignment']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="HorizontalTextAlignmentProperty">
@@ -487,8 +477,6 @@ var editor = new Editor {
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='HorizontalTextAlignmentProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsTextPredictionEnabled">
@@ -832,8 +820,6 @@ var editor = new Editor {
         <param name="newValue">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='OnHorizontalTextAlignmentPropertyChanged']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnTextChanged">
@@ -924,8 +910,6 @@ var editor = new Editor {
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='SelectionLength']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SelectionLengthProperty">
@@ -946,8 +930,6 @@ var editor = new Editor {
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='SelectionLengthProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SendCompleted">
@@ -1039,8 +1021,6 @@ var editor = new Editor {
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='VerticalTextAlignment']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="VerticalTextAlignmentProperty">
@@ -1061,8 +1041,6 @@ var editor = new Editor {
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Editor.xml" path="//Member[@MemberName='VerticalTextAlignmentProperty']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Element.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Element.xml
@@ -230,8 +230,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='ControlsElementMapper']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="DescendantAdded">
@@ -409,8 +407,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='Handler']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="HandlerChanged">
@@ -529,8 +525,6 @@
         <param name="element">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='MapAutomationPropertiesExcludedWithChildren']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapAutomationPropertiesIsInAccessibleTree">
@@ -557,8 +551,6 @@
         <param name="element">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Element.xml" path="//Member[@MemberName='MapAutomationPropertiesIsInAccessibleTree']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IEffectControlProvider.RegisterEffect">

--- a/docs/xml/Microsoft.Maui.Controls/ElementTemplate.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ElementTemplate.xml
@@ -59,8 +59,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ElementTemplate.xml" path="//Member[@MemberName='LoadTemplate']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Entry.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Entry.xml
@@ -303,8 +303,6 @@ View CreateLoginForm ()
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Entry.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -325,8 +323,6 @@ View CreateLoginForm ()
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Entry.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -560,8 +556,6 @@ View CreateLoginForm ()
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Entry.xml" path="//Member[@MemberName='KeyboardProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapText">

--- a/docs/xml/Microsoft.Maui.Controls/FileImageSourceConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/FileImageSourceConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FileImageSourceConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FileImageSourceConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FileImageSourceConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FileImageSourceConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/FlexLayout.xml
+++ b/docs/xml/Microsoft.Maui.Controls/FlexLayout.xml
@@ -370,8 +370,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetAlignSelf'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetBasis">
@@ -425,8 +423,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetBasis'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetFlexFrame">
@@ -455,8 +451,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetFlexFrame']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetGrow">
@@ -510,8 +504,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetGrow'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetOrder">
@@ -565,8 +557,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetOrder'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetShrink">
@@ -620,8 +610,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='GetShrink'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GrowProperty">
@@ -717,8 +705,6 @@
         <param name="height">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='Layout']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnAdd">
@@ -985,8 +971,6 @@
         <param name="alignSelf">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetAlignSelf'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetBasis">
@@ -1039,8 +1023,6 @@
         <param name="basis">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetBasis'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetGrow">
@@ -1093,8 +1075,6 @@
         <param name="grow">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetGrow'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetOrder">
@@ -1153,8 +1133,6 @@
         <param name="order">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetOrder'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetShrink">
@@ -1207,8 +1185,6 @@
         <param name="shrink">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/FlexLayout.xml" path="//Member[@MemberName='SetShrink'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ShrinkProperty">

--- a/docs/xml/Microsoft.Maui.Controls/FlyoutPage.xml
+++ b/docs/xml/Microsoft.Maui.Controls/FlyoutPage.xml
@@ -107,8 +107,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/FlyoutPage.xml" path="//Member[@MemberName='ControlsFlyoutPageMapper']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Detail">

--- a/docs/xml/Microsoft.Maui.Controls/FontAttributesConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/FontAttributesConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontAttributesConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontAttributesConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontAttributesConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontAttributesConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/FontImageSource.xml
+++ b/docs/xml/Microsoft.Maui.Controls/FontImageSource.xml
@@ -102,8 +102,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -124,8 +122,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontImageSource.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/FontSizeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/FontSizeConverter.xml
@@ -64,8 +64,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontSizeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -93,8 +91,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontSizeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -124,8 +120,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontSizeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -157,8 +151,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/FontSizeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">

--- a/docs/xml/Microsoft.Maui.Controls/GestureRecognizer.xml
+++ b/docs/xml/Microsoft.Maui.Controls/GestureRecognizer.xml
@@ -40,8 +40,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/GestureRecognizer.xml" path="//Member[@MemberName='.ctor']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Grid.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Grid.xml
@@ -215,8 +215,6 @@ namespace FormsGallery
         <param name="gridColumnDefinition">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='AddColumnDefinition']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="AddRowDefinition">
@@ -241,8 +239,6 @@ namespace FormsGallery
         <param name="gridRowDefinition">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='AddRowDefinition']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ColumnDefinitions">
@@ -470,8 +466,6 @@ namespace FormsGallery
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumn'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetColumnSpan">
@@ -540,8 +534,6 @@ namespace FormsGallery
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetColumnSpan'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetRow">
@@ -610,8 +602,6 @@ namespace FormsGallery
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRow'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetRowSpan">
@@ -678,8 +668,6 @@ namespace FormsGallery
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='GetRowSpan'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="InvalidateMeasure">
@@ -1102,8 +1090,6 @@ namespace FormsGallery
         <param name="col">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumn'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetColumnSpan">
@@ -1170,8 +1156,6 @@ namespace FormsGallery
         <param name="span">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetColumnSpan'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetRow">
@@ -1238,8 +1222,6 @@ namespace FormsGallery
         <param name="row">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRow'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetRowSpan">
@@ -1304,8 +1286,6 @@ namespace FormsGallery
         <param name="span">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Grid.xml" path="//Member[@MemberName='SetRowSpan'][2]/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/GridLengthTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/GridLengthTypeConverter.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml" path="Type[@FullName='Microsoft.Maui.Controls.GridLengthTypeConverter']/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -62,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -91,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -122,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -155,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/GridLengthTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/ImageSourceConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ImageSourceConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ImageSourceConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ImageSourceConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ImageSourceConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ImageSourceConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/InitializationFlags.xml
+++ b/docs/xml/Microsoft.Maui.Controls/InitializationFlags.xml
@@ -61,8 +61,6 @@
       <MemberValue>2</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/InitializationFlags.xml" path="//Member[@MemberName='SkipRenderers']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/ItemsLayoutTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/ItemsView`1.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ItemsView`1.xml
@@ -338,8 +338,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ItemsView.xml" path="//Member[@MemberName='TemplatedItems']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="UnhookContent">

--- a/docs/xml/Microsoft.Maui.Controls/Label.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Label.xml
@@ -161,8 +161,6 @@ public class App : Application
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='ControlsLabelMapper']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -225,8 +223,6 @@ public class App : Application
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -247,8 +243,6 @@ public class App : Application
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -605,8 +599,6 @@ public class App : Application
         <param name="label">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='MapText']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapTextType">
@@ -633,8 +625,6 @@ public class App : Application
         <param name="label">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/Label.xml" path="//Member[@MemberName='MapTextType']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MaxLines">

--- a/docs/xml/Microsoft.Maui.Controls/Layout.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Layout.xml
@@ -143,8 +143,6 @@
         <param name="child">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Add']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CascadeInputTransparent">
@@ -231,8 +229,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Clear']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Contains">
@@ -261,8 +257,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Contains']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ControlsLayoutMapper">
@@ -312,8 +306,6 @@
         <param name="arrayIndex">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='CopyTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -338,8 +330,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Count']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CreateLayoutManager">
@@ -390,8 +380,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='CrossPlatformArrange']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CrossPlatformMeasure">
@@ -422,8 +410,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='CrossPlatformMeasure']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -449,8 +435,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='GetEnumerator']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IgnoreSafeArea">
@@ -472,8 +456,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='IgnoreSafeArea']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IndexOf">
@@ -502,8 +484,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='IndexOf']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -533,8 +513,6 @@
         <param name="child">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Insert']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="InvalidateMeasureOverride">
@@ -622,8 +600,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='IsReadOnly']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -706,8 +682,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Measure']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IBindableLayout.Children">
@@ -1049,8 +1023,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='Remove']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RemoveAt">
@@ -1078,8 +1050,6 @@
         <param name="index">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Layout.xml" path="//Member[@MemberName='RemoveAt']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerable.GetEnumerator">

--- a/docs/xml/Microsoft.Maui.Controls/LayoutOptionsConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/LayoutOptionsConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetStandardValues">
@@ -180,8 +172,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='GetStandardValues']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetStandardValuesExclusive">
@@ -207,8 +197,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='GetStandardValuesExclusive']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetStandardValuesSupported">
@@ -234,8 +222,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/LayoutOptionsConverter.xml" path="//Member[@MemberName='GetStandardValuesSupported']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/ListStringTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ListStringTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ListStringTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ListStringTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ListStringTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ListStringTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/MessagingCenter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/MessagingCenter.xml
@@ -350,8 +350,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="message">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Send&lt;TSender,TArgs&gt;">
@@ -390,8 +388,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="args">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Send'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Subscribe&lt;TSender&gt;">
@@ -429,8 +425,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="source">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Subscribe&lt;TSender,TArgs&gt;">
@@ -470,8 +464,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="source">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Subscribe'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Unsubscribe&lt;TSender&gt;">
@@ -506,8 +498,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="message">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Unsubscribe&lt;TSender,TArgs&gt;">
@@ -544,8 +534,6 @@ Assert.AreEqual(2, subscriber.IntProperty);
         <param name="message">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/MessagingCenter.xml" path="//Member[@MemberName='Unsubscribe'][1]/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/NameScopeExtensions.xml
+++ b/docs/xml/Microsoft.Maui.Controls/NameScopeExtensions.xml
@@ -47,8 +47,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/NameScopeExtensions.xml" path="//Member[@MemberName='FindByName']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/Page.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Page.xml
@@ -324,8 +324,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='DisplayActionSheet'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="DisplayAlert">
@@ -531,8 +529,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Page.xml" path="//Member[@MemberName='GetParentWindow']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IconImageSource">

--- a/docs/xml/Microsoft.Maui.Controls/PanGestureRecognizer.xml
+++ b/docs/xml/Microsoft.Maui.Controls/PanGestureRecognizer.xml
@@ -64,8 +64,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/PanGestureRecognizer.xml" path="//Member[@MemberName='CurrentId']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IPanGestureController.SendPan">

--- a/docs/xml/Microsoft.Maui.Controls/Picker.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Picker.xml
@@ -273,8 +273,6 @@ namespace FormsGallery
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -295,8 +293,6 @@ namespace FormsGallery
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Picker.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/RadioButton.xml
+++ b/docs/xml/Microsoft.Maui.Controls/RadioButton.xml
@@ -354,8 +354,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='ControlsRadioButtonMapper']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CornerRadius">
@@ -480,8 +478,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -502,8 +498,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RadioButton.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/RadioButtonGroup.xml
+++ b/docs/xml/Microsoft.Maui.Controls/RadioButtonGroup.xml
@@ -132,8 +132,6 @@
         <param name="groupName">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RadioButtonGroup.xml" path="//Member[@MemberName='SetGroupName']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetSelectedValue">
@@ -160,8 +158,6 @@
         <param name="selectedValue">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RadioButtonGroup.xml" path="//Member[@MemberName='SetSelectedValue']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/ReferenceTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ReferenceTypeConverter.xml
@@ -64,8 +64,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -93,8 +91,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -124,8 +120,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -157,8 +151,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ReferenceTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">

--- a/docs/xml/Microsoft.Maui.Controls/RouteFactory.xml
+++ b/docs/xml/Microsoft.Maui.Controls/RouteFactory.xml
@@ -80,8 +80,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RouteFactory.xml" path="//Member[@MemberName='GetOrCreate'][2]/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/RowDefinitionCollectionTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/ScrollToRequestedEventArgs.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ScrollToRequestedEventArgs.xml
@@ -216,8 +216,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/ScrollToRequestedEventArgs.xml" path="//Member[@MemberName='ToRequest']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/SearchBar.xml
+++ b/docs/xml/Microsoft.Maui.Controls/SearchBar.xml
@@ -224,8 +224,6 @@ public class App : Application
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='CursorPosition']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CursorPositionProperty">
@@ -246,8 +244,6 @@ public class App : Application
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='CursorPositionProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAttributes">
@@ -310,8 +306,6 @@ public class App : Application
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -332,8 +326,6 @@ public class App : Application
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">
@@ -484,8 +476,6 @@ public class App : Application
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='IsTextPredictionEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsTextPredictionEnabledProperty">
@@ -506,8 +496,6 @@ public class App : Application
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='IsTextPredictionEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapText">
@@ -977,8 +965,6 @@ public class App : Application
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='SelectionLength']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SelectionLengthProperty">
@@ -999,8 +985,6 @@ public class App : Application
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/SearchBar.xml" path="//Member[@MemberName='SelectionLengthProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="TextColorProperty">

--- a/docs/xml/Microsoft.Maui.Controls/SearchHandler.xml
+++ b/docs/xml/Microsoft.Maui.Controls/SearchHandler.xml
@@ -61,8 +61,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='AutomationId']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="AutomationIdProperty">
@@ -83,8 +81,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='AutomationIdProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="BackgroundColor">
@@ -830,8 +826,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -852,8 +846,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/SearchHandler.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/Shell.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Shell.xml
@@ -91,8 +91,6 @@
         <param name="element">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='AddLogicalChild']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="BackButtonBehaviorProperty">
@@ -555,8 +553,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutContent']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutContentProperty">
@@ -577,8 +573,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutContentProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutContentTemplate">
@@ -600,8 +594,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutContentTemplate']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutContentTemplateProperty">
@@ -622,8 +614,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutContentTemplateProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutFooter">
@@ -645,8 +635,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutFooter']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutFooterProperty">
@@ -667,8 +655,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutFooterProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutFooterTemplate">
@@ -690,8 +676,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutFooterTemplate']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutFooterTemplateProperty">
@@ -712,8 +696,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutFooterTemplateProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutHeader">
@@ -858,8 +840,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutHeight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutHeightProperty">
@@ -880,8 +860,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutHeightProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutIcon">
@@ -984,8 +962,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutItemIsVisibleProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutItems">
@@ -1007,8 +983,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutItems']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutVerticalScrollMode">
@@ -1071,8 +1045,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutWidth']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutWidthProperty">
@@ -1093,8 +1065,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='FlyoutWidthProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ForegroundColorProperty">
@@ -1265,8 +1235,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GetFlyoutHeight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetFlyoutItemIsVisible">
@@ -1292,8 +1260,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GetFlyoutItemIsVisible']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetFlyoutWidth">
@@ -1319,8 +1285,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='GetFlyoutWidth']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetForegroundColor">
@@ -2873,8 +2837,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="element">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='RemoveLogicalChild']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SearchHandlerProperty">
@@ -3051,8 +3013,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='SetFlyoutHeight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetFlyoutItemIsVisible">
@@ -3079,8 +3039,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="isVisible">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='SetFlyoutItemIsVisible']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetFlyoutWidth">
@@ -3107,8 +3065,6 @@ await Shell.Current.GoToAsync("app://xamarin.com/xaminals/animals/monkeys");
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/Shell.xml" path="//Member[@MemberName='SetFlyoutWidth']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SetForegroundColor">

--- a/docs/xml/Microsoft.Maui.Controls/ShellAppearance.xml
+++ b/docs/xml/Microsoft.Maui.Controls/ShellAppearance.xml
@@ -135,8 +135,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/ShellAppearance.xml" path="//Member[@MemberName='FlyoutHeight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FlyoutWidth">
@@ -158,8 +156,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/ShellAppearance.xml" path="//Member[@MemberName='FlyoutWidth']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ForegroundColor">

--- a/docs/xml/Microsoft.Maui.Controls/Span.xml
+++ b/docs/xml/Microsoft.Maui.Controls/Span.xml
@@ -192,8 +192,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -214,8 +212,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/Span.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/TableSectionBase`1.xml
+++ b/docs/xml/Microsoft.Maui.Controls/TableSectionBase`1.xml
@@ -111,8 +111,6 @@
         <param name="items">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -140,8 +138,6 @@
         <param name="item">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Add'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -166,8 +162,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Clear']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CollectionChanged">
@@ -219,8 +213,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Contains']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -250,8 +242,6 @@
         <param name="arrayIndex">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='CopyTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -276,8 +266,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Count']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -303,8 +291,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='GetEnumerator']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IndexOf">
@@ -333,8 +319,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='IndexOf']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Insert">
@@ -364,8 +348,6 @@
         <param name="item">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Insert']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Item">
@@ -493,8 +475,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='Remove']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RemoveAt">
@@ -522,8 +502,6 @@
         <param name="index">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TableSectionBase.xml" path="//Member[@MemberName='RemoveAt']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="System.Collections.Generic.ICollection&lt;T&gt;.IsReadOnly">

--- a/docs/xml/Microsoft.Maui.Controls/TextAlignmentConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/TextAlignmentConverter.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml" path="Type[@FullName='Microsoft.Maui.Controls.TextAlignmentConverter']/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -62,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -91,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -122,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -155,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextAlignmentConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/TextDecorationConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/TextDecorationConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextDecorationConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextDecorationConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextDecorationConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TextDecorationConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/TimePicker.xml
+++ b/docs/xml/Microsoft.Maui.Controls/TimePicker.xml
@@ -191,8 +191,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='FontAutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontAutoScalingEnabledProperty">
@@ -213,8 +211,6 @@ var beeroclock = new TimePicker () { Time = new TimeSpan (17,0,0) };
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TimePicker.xml" path="//Member[@MemberName='FontAutoScalingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="FontFamily">

--- a/docs/xml/Microsoft.Maui.Controls/TriggerAction.xml
+++ b/docs/xml/Microsoft.Maui.Controls/TriggerAction.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../../docs/Microsoft.Maui.Controls/TriggerAction.xml" path="Type[@FullName='Microsoft.Maui.Controls.TriggerAction' and position()=0]/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName="AssociatedType">

--- a/docs/xml/Microsoft.Maui.Controls/TypeTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/TypeTypeConverter.xml
@@ -64,8 +64,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TypeTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -93,8 +91,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TypeTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -124,8 +120,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TypeTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -157,8 +151,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/TypeTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Microsoft.Maui.Controls.IExtendedTypeConverter.ConvertFromInvariantString">

--- a/docs/xml/Microsoft.Maui.Controls/UriImageSource.xml
+++ b/docs/xml/Microsoft.Maui.Controls/UriImageSource.xml
@@ -84,8 +84,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/UriImageSource.xml" path="//Member[@MemberName='CacheValidityProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CachingEnabled">
@@ -127,8 +125,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/UriImageSource.xml" path="//Member[@MemberName='CachingEnabledProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">

--- a/docs/xml/Microsoft.Maui.Controls/UriTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/UriTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/UriTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/UriTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/UriTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/UriTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/VisualElement.xml
+++ b/docs/xml/Microsoft.Maui.Controls/VisualElement.xml
@@ -162,8 +162,6 @@
         <param name="bounds">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Arrange']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ArrangeOverride">
@@ -556,8 +554,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ControlsVisualElementMapper']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="DesiredSize">
@@ -579,8 +575,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='DesiredSize']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="DisableLayout">
@@ -757,8 +751,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Frame']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Handler">
@@ -783,8 +775,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Handler']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Height">
@@ -1160,8 +1150,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='IsInPlatformLayout']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsLoaded">
@@ -1243,8 +1231,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='IsPlatformStateConsistent']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="IsVisible">
@@ -1397,8 +1383,6 @@
         <param name="view">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MapBackgroundColor']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MapBackgroundImageSource">
@@ -1446,8 +1430,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MaximumHeightRequest']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MaximumHeightRequestProperty">
@@ -1468,8 +1450,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MaximumHeightRequestProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MaximumWidthRequest">
@@ -1491,8 +1471,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MaximumWidthRequest']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="MaximumWidthRequestProperty">
@@ -1513,8 +1491,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='MaximumWidthRequestProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Measure">
@@ -2547,8 +2523,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='PlatformSizeChanged']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Resources">
@@ -2864,8 +2838,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='Shadow']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ShadowProperty">
@@ -2886,8 +2858,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ShadowProperty']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="SizeAllocated">
@@ -3415,8 +3385,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../../docs/Microsoft.Maui.Controls/VisualElement.xml" path="//Member[@MemberName='ZIndex']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/VisualTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/VisualTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetStandardValues">
@@ -180,8 +172,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='GetStandardValues']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetStandardValuesExclusive">
@@ -207,8 +197,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='GetStandardValuesExclusive']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="GetStandardValuesSupported">
@@ -234,8 +222,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../../docs/Microsoft.Maui.Controls/VisualTypeConverter.xml" path="//Member[@MemberName='GetStandardValuesSupported']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml
+++ b/docs/xml/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml
@@ -60,8 +60,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml" path="//Member[@MemberName='CanConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="CanConvertTo">
@@ -89,8 +87,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml" path="//Member[@MemberName='CanConvertTo']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertFrom">
@@ -120,8 +116,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml" path="//Member[@MemberName='ConvertFrom']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ConvertTo">
@@ -153,8 +147,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Controls/WebViewSourceTypeConverter.xml" path="//Member[@MemberName='ConvertTo']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui.Media/IScreenshotResult.xml
+++ b/docs/xml/Microsoft.Maui.Media/IScreenshotResult.xml
@@ -41,8 +41,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/IScreenshotResult.xml" path="//Member[@MemberName='CopyToAsync']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Height">

--- a/docs/xml/Microsoft.Maui.Platform/ViewExtensions.xml
+++ b/docs/xml/Microsoft.Maui.Platform/ViewExtensions.xml
@@ -95,8 +95,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/ViewExtensions.xml" path="//Member[@MemberName='ToHandler']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Unfocus">

--- a/docs/xml/Microsoft.Maui.Storage/SecureStorage.xml
+++ b/docs/xml/Microsoft.Maui.Storage/SecureStorage.xml
@@ -149,8 +149,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui.Essentials/SecureStorage.xml" path="//Member[@MemberName='SetAsync'][0 and position()=0]/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui/Aspect.xml
+++ b/docs/xml/Microsoft.Maui/Aspect.xml
@@ -76,8 +76,6 @@
       <MemberValue>3</MemberValue>
       <Docs>
         <summary>To be added.</summary>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Aspect.xml" path="//Member[@MemberName='Center']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Fill">

--- a/docs/xml/Microsoft.Maui/Easing.xml
+++ b/docs/xml/Microsoft.Maui/Easing.xml
@@ -304,8 +304,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Easing.xml" path="//Member[@MemberName='Default']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Ease">

--- a/docs/xml/Microsoft.Maui/Font.xml
+++ b/docs/xml/Microsoft.Maui/Font.xml
@@ -47,8 +47,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='AutoScalingEnabled']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -288,8 +286,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='Slant']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="System.IEquatable&lt;Microsoft.Maui.Font&gt;.Equals">
@@ -376,8 +372,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='SystemFontOfWeight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -421,8 +415,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='Weight']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="WithAutoScaling">
@@ -448,8 +440,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithAutoScaling']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="WithSize">
@@ -500,8 +490,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithSlant']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="WithWeight">
@@ -527,8 +515,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="WithWeight">
@@ -556,8 +542,6 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Font.xml" path="//Member[@MemberName='WithWeight'][2]/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui/Thickness.xml
+++ b/docs/xml/Microsoft.Maui/Thickness.xml
@@ -265,8 +265,6 @@
         <summary>To be added.</summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='IsNaN']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="Left">
@@ -574,8 +572,6 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/Thickness.xml" path="//Member[@MemberName='Zero']/Docs/*" />
       </Docs>
     </Member>
   </Members>

--- a/docs/xml/Microsoft.Maui/VisualDiagnostics.xml
+++ b/docs/xml/Microsoft.Maui/VisualDiagnostics.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="Type[@FullName='Microsoft.Maui.VisualDiagnostics']/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName="CaptureAsJpegAsync">
@@ -177,8 +175,6 @@
         <param name="child">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded'][1]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnChildAdded">
@@ -207,8 +203,6 @@
         <param name="newLogicalIndex">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildAdded'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="OnChildRemoved">
@@ -237,8 +231,6 @@
         <param name="oldLogicalIndex">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../../docs/Microsoft.Maui/VisualDiagnostics.xml" path="//Member[@MemberName='OnChildRemoved']/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RegisterSourceInfo">

--- a/docs/xml/Microsoft.Maui/VisualTreeChangeEventArgs.xml
+++ b/docs/xml/Microsoft.Maui/VisualTreeChangeEventArgs.xml
@@ -16,8 +16,6 @@
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
-    <!-- No matching elements were found for the following include tag -->
-    <include file="../../docs/Microsoft.Maui/VisualTreeChangeEventArgs.xml" path="Type[@FullName='Microsoft.Maui.VisualTreeChangeEventArgs']/Docs/*" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/docs/xml/Microsoft.Maui/WeakEventManager.xml
+++ b/docs/xml/Microsoft.Maui/WeakEventManager.xml
@@ -65,8 +65,6 @@
         <param name="eventName">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../docs/Microsoft.Maui/WeakEventManager.xml" path="//Member[@MemberName='AddEventHandler'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="AddEventHandler&lt;TEventArgs&gt;">
@@ -167,8 +165,6 @@
         <param name="eventName">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
-        <!-- No matching elements were found for the following include tag -->
-        <include file="../docs/Microsoft.Maui/WeakEventManager.xml" path="//Member[@MemberName='RemoveEventHandler'][2]/Docs/*" />
       </Docs>
     </Member>
     <Member MemberName="RemoveEventHandler&lt;TEventArgs&gt;">


### PR DESCRIPTION
Because the binaries had XML docs that pointed to non-existent nodes in the external XML files, mdoc now generated these warnings.

However, when parsing these nodes for an update, the docs generation will break over these dead links.