### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,7 +1,0 @@
-- name: .NET
-  tocHref: /dotnet/
-  topicHref: /dotnet/index
-  items:
-  - name: API browser
-    tocHref: /dotnet/api/
-    topicHref: /dotnet/api/index

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -42,7 +42,7 @@
     "globalMetadata": {
       "apiPlatform": "dotnet",
       "author": "dotnet-bot",
-      "breadcrumb_path": "/dotnet/breadcrumb/toc.json",
+      "breadcrumb_path": "/dotnet/dotnet-maui-api-docs-breadcrumb/toc.json",
       "ms.topic": "managed-reference",
       "ms.author": "dotnetcontent",
       "ms.date": "10/03/2022",
@@ -51,7 +51,7 @@
       "defaultDevLang": "csharp",
       "feedback_system": "None",
       "searchScope": [".NET MAUI"],
-      "uhfHeaderId": "MSDocsHeader-DotNet"
+      "uhfHeaderId": "MSDocsHeader-DotNetMaui"
     },
     "fileMetadata": {
       "author": {

--- a/docs/dotnet-maui-api-docs-breadcrumb/toc.yml
+++ b/docs/dotnet-maui-api-docs-breadcrumb/toc.yml
@@ -5,7 +5,7 @@
   - name: .NET MAUI
     tocHref: /dotnet/
     topicHref: /dotnet/maui/index
-      items:
+    items:
     - name: API browser
       tocHref: /dotnet/api/
       topicHref: /dotnet/api/index

--- a/docs/dotnet-maui-api-docs-breadcrumb/toc.yml
+++ b/docs/dotnet-maui-api-docs-breadcrumb/toc.yml
@@ -1,0 +1,12 @@
+- name: .NET
+  tocHref: /dotnet/
+  topicHref: /dotnet/index
+  items:
+  - name: .NET MAUI
+    tocHref: /dotnet/
+    topicHref: /dotnet/maui/index
+      items:
+    - name: API browser
+      tocHref: /dotnet/api/
+      topicHref: /dotnet/api/index
+


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.

Note: Also changed uhfHeaderId to .NET MAUI header.