### PR TITLE
Add documentation for AuthenticateAsync exceptions

### DIFF
--- a/docs/xml/Microsoft.Maui.Authentication/WebAuthenticator.xml
+++ b/docs/xml/Microsoft.Maui.Authentication/WebAuthenticator.xml
@@ -45,6 +45,7 @@
         <param name="webAuthenticatorOptions">Options to configure the authentication request.</param>
         <summary>Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.The start url and callbackUrl are specified in the webAuthenticatorOptions.</summary>
         <returns>Returns a result parsed out from the callback url.</returns>
+        <exception cref="TaskCanceledException">The user canceled the authentication flow.</exception>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -72,6 +73,7 @@
         <param name="callbackUrl"> Expected callback url that the navigation flow will eventually redirect to.</param>
         <summary>Begin an authentication flow by navigating to the specified url and waiting for a callback/redirect to the callbackUrl scheme.</summary>
         <returns>Returns a result parsed out from the callback url.</returns>
+        <exception cref="TaskCanceledException">The user canceled the authentication flow.</exception>
         <remarks />
       </Docs>
     </Member>


### PR DESCRIPTION
If the user cancels the authentication process this method throws a TaskCanceledException. This PR adds the missing documentation for this. This relates to issue #72 